### PR TITLE
Yorp: Make Keen dismount the pogo on squishing yorps

### DIFF
--- a/src/actions/VKA_Yorp.h
+++ b/src/actions/VKA_Yorp.h
@@ -76,6 +76,8 @@ int VKF_yorp_collide(vk_object *obj, vk_object *cobj){
 					VK_SetObjAnimation(obj,&VKA_yorp_hit_1);
 					obj->var4 = 0x140;
 					obj->vel_x = 0;
+					// Keen stops pogo-ing
+					VK_SetObjAnimation(cobj,&VKA_keen_idle);
 					// Play sound
 					VK_PlaySound(VKS_YORPBOPSND);
 					return 1;


### PR DESCRIPTION
In the original game, Keen will stop pogo-ing when he squishes a yorp.
This is implemented in the original game by Keen setting his 'think' function to the standard 'on ground' one upon squishing a yorp. It looks like having the yorp update Keen's animation should work here.

Tested on an AGS-101 Gameboy Advance SP, seems fine.